### PR TITLE
Add VSCode Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+RUN apt update && apt install -y \
+    build-essential \
+    pkg-config \
+    cmake \
+    libboost-dev \
+    libboost-program-options-dev \
+    lsb-release \
+    software-properties-common \
+    gnupg \
+    apt-transport-https \
+    bear
+
+# Install dkp-pacman
+RUN mkdir -p /usr/local/share/keyring/ && \
+    wget -O /usr/local/share/keyring/devkitpro-pub.gpg https://apt.devkitpro.org/devkitpro-pub.gpg && \
+    echo "deb [signed-by=/usr/local/share/keyring/devkitpro-pub.gpg] https://apt.devkitpro.org stable main" \
+        > /etc/apt/sources.list.d/devkitpro.list && \
+    apt update && \
+    apt install -y devkitpro-pacman
+
+# Install devkitPPC
+RUN bash -c '[[ ! -f /etc/mtab ]] && ln -s /proc/mounts /etc/mtab || true' && \
+    dkp-pacman -S gamecube-dev --noconfirm
+ENV DEVKITPPC=/opt/devkitpro/devkitPPC
+
+# Install latest clangd
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" && \
+    ln -s /usr/bin/clangd-* /usr/local/bin/clangd

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "SMB2WorkshopMod",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"postCreateCommand": "script/configure-clion-project.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"llvm-vs-code-extensions.vscode-clangd"
+			]
+		}
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,4 @@ __pycache__/
 /ApeSphere.*
 /.qtc_clangd
 /out
+/.cache


### PR DESCRIPTION
This adds an Ubuntu 22.04 Dev Container configuration, complete with the necessary build time dependencies, `compile_commands.json` generation, and clangd for its language server's editor integration. It's mostly a copy-paste from SMB2PracticeMod. This lets you get a development environment up with one command on any OS if you're using VSCode. I saw CLion supposedly added Dev Container support recently so maybe it works there too? I've only tested with VSCode though.